### PR TITLE
FIX CSES PARSING AND GROUPING

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "codeforces-pro",
-    "version": "1.2.0",
+    "version": "1.3.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "codeforces-pro",
-            "version": "1.2.0",
+            "version": "1.3.2",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.7.9",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "codeforces-pro",
     "displayName": "Codeforces Pro",
     "description": "Solve codeforces problems from vscode",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "author": "codewithsathya",
     "publisher": "codewithsathya",
     "license": "MIT",

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -129,44 +129,44 @@ export async function listCsesProblems(): Promise<Record<string, IProblem[]>> {
             );
             const $ = cheerio.load(htmlPage as string);
 
-            const contentChildren = $(".content").first().children().toArray();
-
-            const nodes = contentChildren.slice(3, contentChildren.length - 3);
-
             const problems: Record<string, IProblem[]> = {};
             const csesStatus = globalState.getCsesStatus();
-            for (let i = 0; i < nodes.length; i += 2) {
-                const titleNode = $(nodes[i]);
-                const title = titleNode.text().trim() || "Untitled";
 
-                const problemsNode = $(nodes[i + 1]);
-                const problemNodes = problemsNode.children().toArray();
+            $(".content h2").each((_i: number, headerElement: any) => {
+                const title = $(headerElement).text().trim();
+                
+                if (!title || title === "General") {
+                    return;
+                }
 
-                problems[title] = [];
+                const currentCategoryProblems: IProblem[] = [];
+                const taskList = $(headerElement).nextAll("ul.task-list").first();
+                const problemNodes = taskList.find("li.task").toArray();
 
                 for (const problemEl of problemNodes) {
-                    const problemNode = $(problemEl);
+                    const problemNode = $(problemEl as any);
                     const anchor = problemNode.find("a").first();
                     const detail = problemNode.find(".detail").first();
 
-                    if (!anchor.length || !detail.length) {
+                    if (!anchor.length) {
                         continue;
                     }
 
                     const problemName = anchor.text().trim();
                     const problemLink = anchor.attr("href") ?? "";
-                    const solvedText = detail.text() ?? "0 / ?";
-                    const solvedCount = parseInt(
-                        solvedText.split("/")[0].trim(),
-                    );
+                    const solvedText = detail.text().trim() || "0 / 0";
+                    const solvedCount = parseInt(solvedText.split("/")[0].trim()) || 0;
+                    
                     const problemId = problemLink.split("/").pop() ?? "0";
+                    
                     let state: ProblemState = ProblemState.UNKNOWN;
-                    if(csesStatus[problemId] === true) {
+                    if (csesStatus[problemId] === true) {
                         state = ProblemState.ACCEPTED;
                     } else if (csesStatus[problemId] === false) {
                         state = ProblemState.WRONG_ANSWER;
                     }
-                    const problem: IProblem = {
+
+                    currentCategoryProblems.push({
                         isFavorite: false,
                         id: `${problemId}:cses`,
                         name: problemName,
@@ -176,11 +176,13 @@ export async function listCsesProblems(): Promise<Record<string, IProblem[]>> {
                         tags: [],
                         solvedCount,
                         platform: "cses",
-                    };
-
-                    problems[title].push(problem);
+                    });
                 }
-            }
+
+                if (currentCategoryProblems.length > 0) {
+                    problems[title] = currentCategoryProblems;
+                }
+            });
 
             return problems;
         });


### PR DESCRIPTION
The CSES website may had recently updated its structure, which broke the extension's previous parsing logic. The old method relied on array indexing and an even/odd child node pattern `nodes.slice(3, ...))`, which now results in individual problems being incorrectly rendered as folders.

This PR updates the parser to a more robust, selector-based approach that maps categories and problems according to the current site layout.

Changes
1. Replaced fragile indexing with h2 and ul.task-list selectors for better reliability.
2. Added logic to skip the "General" header and ignore empty categories.

Testing
I verified locally using the Extension Development Host. After clearing the local cache, the CSES Problemset now correctly displays categories as folders with the appropriate problems nested inside.

Before
<img width="320" height="420" alt="Screenshot 2026-01-17 at 12 53 57 pm" src="https://github.com/user-attachments/assets/516d0e93-3e18-4b06-98a4-c502eb69d779" />

After
<img width="272" height="623" alt="Screenshot 2026-01-17 at 12 55 15 pm" src="https://github.com/user-attachments/assets/ba65d1cc-e09f-403c-8d61-f880c17452f6" />

Fixes #19 